### PR TITLE
feat: simplify parry 0.22.0-beta.1 integration + enable simd on parry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ chrono = "0.4"
 csv = "1.3"
 bvh = { version = "0.11", default-features = false }
 nalgebra = { version = "0.33" } # Only for svenstaro & parry3d bvh crates
-parry3d = "0.22.0-beta.1"
+parry3d = { version = "0.22.0-beta.1", features = [ "simd-stable" ] }
 serde_json = "1.0"
 tinybvh-rs = { version = "0.1.0-beta.2", optional = true } # No support for cwbvh traversal
 #tinybvh-rs = { git = "https://github.com/DGriffin91/tinybvh-rs", rev = "enable_cwbvh", optional = true }

--- a/src/cwbvh.rs
+++ b/src/cwbvh.rs
@@ -99,7 +99,7 @@ pub fn cwbvh_from_tris(
     };
 
     if options.verbose {
-        println!("{}", bvh.validate(triangles, false));
+        println!("{}", bvh.validate(triangles, false, false));
     }
     bvh
 }

--- a/src/parry.rs
+++ b/src/parry.rs
@@ -1,35 +1,26 @@
 use glam::Mat4;
 use nalgebra::{Point, SVector};
 use obvhs::ray::{Ray, RayHit};
-use parry3d::query::RayCast;
-use parry3d::shape::TriMesh;
+use parry3d::partitioning::{Bvh, BvhBuildStrategy};
 use std::time::{Duration, Instant};
-use traversable::{SceneTri, Traversable};
+use traversable::{Intersectable, SceneTri, Traversable};
 
 impl Traversable for ParryScene {
     type Primitive = SceneTri;
 
     #[inline(always)]
     fn traverse(&self, ray: Ray) -> RayHit {
-        let ray_s = parry3d::query::Ray::new(
+        let mut ray_s = parry3d::query::Ray::new(
             Point::<f32, 3>::from(Into::<[f32; 3]>::into(ray.origin)),
             SVector::<f32, 3>::from(Into::<[f32; 3]>::into(ray.direction)),
         );
+        ray_s.origin = ray_s.point_at(ray.tmin);
 
-        let hit = self
-            .tri_mesh
-            .bvh()
-            .cast_ray(&ray_s, f32::MAX, |primitive, best_so_far| {
-                if let Some(hit) =
-                    self.parry_tris[primitive as usize].cast_local_ray(&ray_s, best_so_far, true)
-                {
-                    if hit < best_so_far {
-                        return Some(hit);
-                    }
-                }
-                None
-            });
-        if let Some((primitive_id, t)) = hit {
+        if let Some((primitive_id, t)) =
+            self.bvh.cast_ray(&ray_s, ray.tmax - ray.tmin, |tri_id, _| {
+                Some(self.tris[tri_id as usize].intersect(&ray))
+            })
+        {
             RayHit {
                 primitive_id,
                 t,
@@ -52,38 +43,28 @@ impl Traversable for ParryScene {
 }
 
 pub struct ParryScene {
-    pub tri_mesh: TriMesh,
+    pub bvh: Bvh,
     pub tris: Vec<SceneTri>,
-    pub parry_tris: Vec<parry3d::shape::Triangle>,
 }
 
 impl ParryScene {
     pub fn new(tris: &[obvhs::triangle::Triangle], core_build_time: &mut Duration) -> Self {
-        let mut parry_verts = Vec::with_capacity(tris.len());
-        let mut indices = Vec::with_capacity(tris.len());
-        for (tri_idx, t) in tris.iter().enumerate() {
-            let p0 = Point::<f32, 3>::from(Into::<[f32; 3]>::into(t.v0));
-            let p1 = Point::<f32, 3>::from(Into::<[f32; 3]>::into(t.v1));
-            let p2 = Point::<f32, 3>::from(Into::<[f32; 3]>::into(t.v2));
-            parry_verts.push(p0);
-            parry_verts.push(p1);
-            parry_verts.push(p2);
-            let index = tri_idx as u32 * 3;
-            indices.push([index + 0, index + 1, index + 2]);
-        }
+        let parry_tris = tris
+            .iter()
+            .map(|t| {
+                parry3d::shape::Triangle::new(
+                    Point::<f32, 3>::from(Into::<[f32; 3]>::into(t.v0)),
+                    Point::<f32, 3>::from(Into::<[f32; 3]>::into(t.v1)),
+                    Point::<f32, 3>::from(Into::<[f32; 3]>::into(t.v2)),
+                )
+            });
+        let indexed_aabbs = parry_tris.map(|tri| tri.local_aabb()).enumerate();
         let tris = tris.iter().map(|t| SceneTri(t.clone())).collect::<Vec<_>>();
 
         let start_time = Instant::now();
-        let tri_mesh = TriMesh::new(parry_verts, indices).unwrap();
+        let bvh = Bvh::from_iter(BvhBuildStrategy::Ploc, indexed_aabbs);
         *core_build_time += start_time.elapsed();
 
-        // Can this be avoided? It's not counted in core_build_time.
-        let parry_tris = tri_mesh.triangles().collect();
-
-        ParryScene {
-            tri_mesh,
-            tris,
-            parry_tris,
-        }
+        ParryScene { bvh, tris }
     }
 }


### PR DESCRIPTION
This PR makes a few adjustments on the way parry is being used:
- By default SIMD (sse/sse2) optimizations are disabled in parry. This PR enables them with the `simd_stable` feature.
- The `Bvh` can be constructed directly, without `TriMesh`. This allows selecting the construction method (here set to non-parallel PLOC).
- There is no requirement to use parry triangles, so the `// Can this be avoided? It's not counted in core_build_time.` part can be removed.