### PR TITLE
Migrate to tinybvh beta 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ bytemuck = "1"
 image = "0.24"
 winit = "0.29"
 tabled = "0.15"
-glam = { version = "0.32.1", features = ["bytemuck", "serde"] }
+glam = { version = "0.32", features = ["bytemuck", "serde"] }
 ron = "0.8"
 serde = { version = "1", features = ["derive"] }
 rayon = "1.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,8 +70,7 @@ opt-level = 3
 
 
 [features]
-default = ["tinybvh", "embree"]
-# default = ["tinybvh"]
+#default = ["tinybvh", "embree"]
 embree = ["dep:obvhs_embree", "dep:embree4-sys"]
 tinybvh = ["dep:tinybvh-rs"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ bytemuck = "1"
 image = "0.24"
 winit = "0.29"
 tabled = "0.15"
-glam = { version = "0.31", features = ["bytemuck", "serde"] }
+glam = { version = "0.32.1", features = ["bytemuck", "serde"] }
 ron = "0.8"
 serde = { version = "1", features = ["derive"] }
 rayon = "1.10"
@@ -35,9 +35,9 @@ chrono = "0.4"
 csv = "1.3"
 svenstaro = { package = "bvh", version = "0.12", default-features = false, features = ["std"] }
 nalgebra = { version = "0.34" } # Only for svenstaro & parry3d bvh crates
-parry3d = { version = "0.26", features = ["simd-stable"] }
+parry3d = { version = "0.28", features = ["simd-stable"] }
 serde_json = "1.0"
-tinybvh-rs = { version = "0.1.0-beta.2", optional = true } # No support for cwbvh traversal
+tinybvh-rs = { version = "0.1.0-beta.3", optional = true } # No support for cwbvh traversal
 #tinybvh-rs = { git = "https://github.com/DGriffin91/tinybvh-rs", rev = "enable_cwbvh", optional = true }
 # Haven't been able to get CWBVH to work.
 # With `tinybvh @ 33f2158` I always get back prim 0
@@ -70,7 +70,8 @@ opt-level = 3
 
 
 [features]
-#default = ["tinybvh", "embree"]
+default = ["tinybvh", "embree"]
+# default = ["tinybvh"]
 embree = ["dep:obvhs_embree", "dep:embree4-sys"]
 tinybvh = ["dep:tinybvh-rs"]
 

--- a/embree/Cargo.toml
+++ b/embree/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-glam = { version = "0.32.1", features = ["bytemuck"] }
+glam = { version = "0.32", features = ["bytemuck"] }
 half = "2.3.1"
 bytemuck = "1.15"
 radsort = "0.1"

--- a/embree/Cargo.toml
+++ b/embree/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-glam = { version = "0.31", features = ["bytemuck"] }
+glam = { version = "0.32.1", features = ["bytemuck"] }
 half = "2.3.1"
 bytemuck = "1.15"
 radsort = "0.1"

--- a/src/tinybvh.rs
+++ b/src/tinybvh.rs
@@ -39,7 +39,7 @@ impl Traversable for TinyBvhScene<'_> {
 }
 
 pub struct TinyBvhScene<'a> {
-    pub bvh: tinybvh_rs::wald::BVH<'a>,
+    pub bvh: tinybvh_rs::bvh::BVH<'a>,
     pub tris: Vec<SceneTri>,
 }
 
@@ -66,14 +66,14 @@ impl TinyBvhScene<'_> {
         let leaked_tris: &'static [[f32; 4]] = Box::leak(tinybvh_tris.clone().into_boxed_slice());
 
         let start_time = Instant::now();
-        let bvh = tinybvh_rs::wald::BVH::new(leaked_tris);
+        let bvh = tinybvh_rs::bvh::BVH::new((*leaked_tris).into()).unwrap();
         *core_build_time += start_time.elapsed();
 
         TinyBvhScene { bvh, tris }
     }
 }
 
-impl Traversable for TinyBvhCwbvhScene<'_> {
+impl Traversable for TinyBvhCwbvhScene {
     type Primitive = SceneTri;
 
     #[inline(always)]
@@ -105,16 +105,16 @@ impl Traversable for TinyBvhCwbvhScene<'_> {
     }
 }
 
-pub struct TinyBvhCwbvhScene<'a> {
+pub struct TinyBvhCwbvhScene {
     #[allow(dead_code)]
-    pub cwbvh: tinybvh_rs::cwbvh::BVH<'a>,
+    pub cwbvh: tinybvh_rs::cwbvh::BVH,
     pub tris: Vec<SceneTri>,
 }
 
-unsafe impl<'a> Send for TinyBvhCwbvhScene<'a> {}
-unsafe impl<'a> Sync for TinyBvhCwbvhScene<'a> {}
+unsafe impl Send for TinyBvhCwbvhScene {}
+unsafe impl Sync for TinyBvhCwbvhScene {}
 
-impl TinyBvhCwbvhScene<'_> {
+impl TinyBvhCwbvhScene {
     pub fn new(
         tris: &[obvhs::triangle::Triangle],
         core_build_time: &mut Duration,
@@ -134,19 +134,20 @@ impl TinyBvhCwbvhScene<'_> {
 
         let tris = tris.iter().map(|t| SceneTri(t.clone())).collect::<Vec<_>>();
 
-        // TODO don't leak
-        let leaked_tris: &'static [[f32; 4]] = Box::leak(tinybvh_tris.clone().into_boxed_slice());
-
         let start_time = Instant::now();
-        let bvh = if hq {
+        let mut bvh = if hq {
             // Note: uses splits
-            tinybvh_rs::cwbvh::BVH::new_hq(leaked_tris)
+            tinybvh_rs::bvh::BVH::new_hq(tinybvh_tris.as_slice().into()).unwrap()
         } else {
-            tinybvh_rs::cwbvh::BVH::new(leaked_tris)
+            tinybvh_rs::bvh::BVH::new(tinybvh_tris.as_slice().into()).unwrap()
         };
+        bvh.split_leaves(3);
+
+        let mbvh = tinybvh_rs::mbvh::BVH::new(&bvh);
+        let cwbvh = tinybvh_rs::cwbvh::BVH::new(&mbvh).unwrap();
         *core_build_time += start_time.elapsed();
 
-        TinyBvhCwbvhScene { cwbvh: bvh, tris }
+        TinyBvhCwbvhScene { cwbvh, tris }
     }
 }
 

--- a/traversable/Cargo.toml
+++ b/traversable/Cargo.toml
@@ -8,4 +8,4 @@ obvhs = { git = "https://github.com/DGriffin91/obvhs", features = [
     "profile",
     "profile-with-tracing",
 ] }
-glam = { version = "0.32.1", features = ["bytemuck"] }
+glam = { version = "0.32", features = ["bytemuck"] }

--- a/traversable/Cargo.toml
+++ b/traversable/Cargo.toml
@@ -8,4 +8,4 @@ obvhs = { git = "https://github.com/DGriffin91/obvhs", features = [
     "profile",
     "profile-with-tracing",
 ] }
-glam = { version = "0.31", features = ["bytemuck"] }
+glam = { version = "0.32.1", features = ["bytemuck"] }


### PR DESCRIPTION
I made some changes to the tinybvh-rs API a few months back, since I wanted to compare it to the ploc builder.

Here is an upgrade of the "new" API. Unfortunately the API isn't as friendly due to the unsafety nature of tinybvh.

Here are the timings for my M3 (obviously build time only matters here):

```sh
❯ cargo run --release -- -i "assets/scenes/kitchen.ron" --benchmark --build tinybvh_cwbvh --cpu
 name      traversal_ms   blas_build_time_s   tlas_build_time_ms
 kitchen   11.371231      0.009579736         0
 Avg       11.371231      0.009579736         0

 ❯ cargo run --release -- -i "assets/scenes/kitchen.ron" --benchmark --build ploc_cwbvh --cpu
 name      traversal_ms   blas_build_time_s   tlas_build_time_ms
 kitchen   149.4867       0.024564251         0
 Avg       149.4867       0.024564251         0
 ```
 
 Wanted to try Bistro, but I think the obj file is missing. I could just use one locally.